### PR TITLE
Bug fixes

### DIFF
--- a/components/ClubPage/InfoBox.js
+++ b/components/ClubPage/InfoBox.js
@@ -6,7 +6,7 @@ export default (props) => (
       <i className="fa-fw fas fa-user-friends"></i>
       {' ' + getSizeDisplay(props.club.size)}
     </p>
-    { props.club.application_required ? (<p><i className="fa-fw fas fa-door-open"></i> Application Required</p>) : (<p><i className="fas fa-door-closed"></i> No Application Required</p>) }
-    { props.club.accepting_applications === 3 ? (<p><i className="fa-fw fas fa-user-plus"></i> Accepting Applications for All Roles</p>) : props.club.accepting_applications === 2 ? (<p><i className="fas fa-user-plus"></i> Accepting Applications for Some Roles</p>) : (<p><i className="fas fa-user-times"></i> Not Accepting Applications</p>) }
+    { props.club.accepting_members ? (<p><i className="fa-fw fas fa-door-open"></i> Currently Accepting Members</p>) : (<p><i className="fas fa-door-closed"></i> Not Currently Accepting Members</p>) }
+    { props.club.application_required === 3 ? (<p><i className="fa-fw fas fa-user-plus"></i> Application Required for All Roles</p>) : props.club.application_required === 2 ? (<p><i className="fas fa-user-plus"></i> Application Required for Some Roles</p>) : (<p><i className="fas fa-user-times"></i> No Application Required</p>) }
   </div>
 )

--- a/components/DropdownFilter.js
+++ b/components/DropdownFilter.js
@@ -61,7 +61,7 @@ const TableWrapper = s.div`
   overflow: hidden;
 
   ${({ drop }) => drop && `
-    max-height: 100vh;
+    max-height: none;
     opacity: 1;
   `}
 


### PR DESCRIPTION
Sorry for having to dip early yesterday :/

This PR fixes the clipping of tag filters when there's a lot of tags. The bug was basically that if the height of the tag list was more than the height of the window, it would cut off since `max-height` was `100vh`. Now it will display the whole list without a maximum height.

It also fixes the application required/members accepted status lines on the club detail page, which before were always reading application required/membership closed.