### PR TITLE
Add colored check boxes (back)

### DIFF
--- a/components/ClubCard.js
+++ b/components/ClubCard.js
@@ -38,7 +38,8 @@ const Card = s.div`
   background-color: ${({ hovering }) => (hovering ? HOVER_GRAY : WHITE)};
   border: 1px solid ${ALLBIRDS_GRAY};
   justify-content: space-between;
-  height: 100%;
+  height: auto;
+  cursor: pointer;
 
   &:hover,
   &:active,
@@ -87,6 +88,7 @@ const ClubCard = ({
 }) => {
   const {
     name,
+    active,
     description,
     subtitle,
     tags,
@@ -103,7 +105,7 @@ const ClubCard = ({
   return (
     <CardWrapper className="column is-half-desktop">
       <a href={CLUB_ROUTE(code)} target="_BLANK">
-        <Card className="card" style={{ cursor: 'pointer', height: '100%' }}>
+        <Card className="card">
           <div style={{ display: 'flex' }}>
             <div style={{ flex: 1 }}>
               <div>
@@ -117,7 +119,7 @@ const ClubCard = ({
                   <CardTitle className="is-size-5">{name}</CardTitle>
                 </CardHeader>
               </div>
-              {club.active || (
+              {!active && (
                 <InactiveTag className="tag is-rounded">Inactive</InactiveTag>
               )}
               <TagGroup

--- a/components/DropdownFilter.js
+++ b/components/DropdownFilter.js
@@ -19,7 +19,12 @@ import {
 import { logEvent } from '../utils/analytics'
 import Icon from './common/Icon'
 
-// TODO colored check boxes
+// Helper map for getting icon posftix from icon name
+const colorToColorNameMap = {
+  [CLUBS_BLUE]: '-blue',
+  [CLUBS_RED]: '-red',
+  [CLUBS_YELLOW]: '-yellow',
+}
 
 const checkboxColorMap = {
   Type: CLUBS_BLUE,
@@ -139,6 +144,7 @@ const DropdownFilter = ({ selected, name, options, updateTag }) => {
   }
 
   const color = checkboxColorMap[name]
+  const iconPostfix = colorToColorNameMap[color] || ''
 
   return (
     <>
@@ -167,7 +173,12 @@ const DropdownFilter = ({ selected, name, options, updateTag }) => {
                     }}
                   >
                     <Icon
-                      name={isSelected(tag) ? 'check-square' : 'square'}
+                      style={{ transform: 'none' }}
+                      name={
+                        isSelected(tag)
+                          ? `check-box${iconPostfix}`
+                          : `box${iconPostfix}`
+                      }
                       alt={isSelected(tag) ? 'selected' : 'not selected'}
                     />
                     &nbsp;

--- a/static/img/icons/box-blue.svg
+++ b/static/img/icons/box-blue.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#60B8F2" xml:space="preserve">
+	<path d="M408,51v357H51V51H408 M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51
+			C459,22.95,436.05,0,408,0L408,0z"/>
+</svg>

--- a/static/img/icons/box-red.svg
+++ b/static/img/icons/box-red.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#FF776D" xml:space="preserve">
+	<path d="M408,51v357H51V51H408 M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51
+			C459,22.95,436.05,0,408,0L408,0z"/>
+</svg>

--- a/static/img/icons/box-yellow.svg
+++ b/static/img/icons/box-yellow.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#FFCF59" xml:space="preserve">
+	<path d="M408,51v357H51V51H408 M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51
+			C459,22.95,436.05,0,408,0L408,0z"/>
+</svg>

--- a/static/img/icons/box.svg
+++ b/static/img/icons/box.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#000" xml:space="preserve">
+	<path d="M408,51v357H51V51H408 M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51
+			C459,22.95,436.05,0,408,0L408,0z"/>
+</svg>

--- a/static/img/icons/check-box-blue.svg
+++ b/static/img/icons/check-box-blue.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#60B8F2" xml:space="preserve">
+	<path d="M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51C459,22.95,436.05,0,408,0z
+			 M178.5,357L51,229.5l35.7-35.7l91.8,91.8L372.3,91.8l35.7,35.7L178.5,357z"/>
+</svg>

--- a/static/img/icons/check-box-red.svg
+++ b/static/img/icons/check-box-red.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#FF776D" xml:space="preserve">
+	<path d="M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51C459,22.95,436.05,0,408,0z
+			 M178.5,357L51,229.5l35.7-35.7l91.8,91.8L372.3,91.8l35.7,35.7L178.5,357z"/>
+</svg>

--- a/static/img/icons/check-box-yellow.svg
+++ b/static/img/icons/check-box-yellow.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#FFCF59" xml:space="preserve">
+	<path d="M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51C459,22.95,436.05,0,408,0z
+			 M178.5,357L51,229.5l35.7-35.7l91.8,91.8L372.3,91.8l35.7,35.7L178.5,357z"/>
+</svg>

--- a/static/img/icons/check-box.svg
+++ b/static/img/icons/check-box.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="459px" height="459px" viewBox="0 0 459 459" fill="#000" xml:space="preserve">
+	<path d="M408,0H51C22.95,0,0,22.95,0,51v357c0,28.05,22.95,51,51,51h357c28.05,0,51-22.95,51-51V51C459,22.95,436.05,0,408,0z
+			 M178.5,357L51,229.5l35.7-35.7l91.8,91.8L372.3,91.8l35.7,35.7L178.5,357z"/>
+</svg>


### PR DESCRIPTION
They were removed when I ported over to feather-icons, now I added em back:

![image](https://user-images.githubusercontent.com/22210251/68055149-5fa6c580-fcc6-11e9-9fb0-84dc3d705e8a.png)
