### PR TITLE
Render Club Page Server Side

### DIFF
--- a/components/TabView.js
+++ b/components/TabView.js
@@ -44,7 +44,8 @@ const Tabs = s.div``
 
 const TabView = ({ tabs, tabClassName, background }) => {
   // the server side rendering does not have a window object
-  const hashString = typeof window !== 'undefined' ? window.location.hash.substring(1) : null
+  const hashString =
+    typeof window !== 'undefined' ? window.location.hash.substring(1) : null
   const [currentTab, setCurrentTab] = useState(hashString || tabs[0].name)
 
   const getTabContent = () =>

--- a/pages/club/[club]/index.js
+++ b/pages/club/[club]/index.js
@@ -1,5 +1,5 @@
 import s from 'styled-components'
-
+import { useState, useEffect } from 'react'
 import renderPage from '../../../renderPage.js'
 import { doApiRequest } from '../../../utils'
 import Tabs from '../../../components/ClubPage/Tabs'
@@ -83,7 +83,7 @@ Club.getInitialProps = async props => {
   const { query } = props
   const resp = await doApiRequest(`/clubs/${query.club}/?format=json`)
   const club = await resp.json()
-  return { club }
+  return { serverClub: club }
 }
 
 export default renderPage(Club)

--- a/pages/club/[club]/index.js
+++ b/pages/club/[club]/index.js
@@ -34,7 +34,9 @@ const Club = ({ club: initialClub, userInfo, favorites, updateFavorites, subscri
   }, [initialClub])
 
   if (!club) return null
-  if (!club.code) {
+
+  const { code } = club
+  if (!code) {
     return (
       <Container>
         <div className="has-text-centered">

--- a/pages/club/[club]/index.js
+++ b/pages/club/[club]/index.js
@@ -83,7 +83,7 @@ Club.getInitialProps = async props => {
   const { query } = props
   const resp = await doApiRequest(`/clubs/${query.club}/?format=json`)
   const club = await resp.json()
-  return { serverClub: club }
+  return { club }
 }
 
 export default renderPage(Club)

--- a/pages/club/[club]/index.js
+++ b/pages/club/[club]/index.js
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import s from 'styled-components'
 
 import renderPage from '../../../renderPage.js'

--- a/pages/club/[club]/index.js
+++ b/pages/club/[club]/index.js
@@ -25,14 +25,14 @@ const Image = s.img`
   object-fit: contain;
 `
 
-const Club = ({ query, userInfo, favorites, updateFavorites, subscriptions, updateSubscriptions }) => {
-  const [club, setClub] = useState(null)
+const Club = ({ club: initialClub, userInfo, favorites, updateFavorites, subscriptions, updateSubscriptions }) => {
+  const [club, setClub] = useState(initialClub)
 
   useEffect(() => {
-    doApiRequest(`/clubs/${query.club}/?format=json`)
+    doApiRequest(`/clubs/${club.code}/?format=json`)
       .then(resp => resp.json())
       .then(data => setClub(data))
-  }, [query])
+  }, [initialClub])
 
   if (!club) return null
   if (!club.code) {
@@ -80,8 +80,11 @@ const Club = ({ query, userInfo, favorites, updateFavorites, subscriptions, upda
   )
 }
 
-Club.getInitialProps = async ({ query }) => {
-  return { query }
+Club.getInitialProps = async props => {
+  const { query } = props
+  const resp = await doApiRequest(`/clubs/${query.club}/?format=json`)
+  const club = await resp.json()
+  return { club }
 }
 
 export default renderPage(Club)


### PR DESCRIPTION
This PR moves the fetch for club info on the club detail page into the `getInitialProps` call. Now, nextjs will render all club details server-side and send the page to the client. This is preferable for a few reasons:
1. SEO -- web crawlers will now get all the HTML for the page without having to run JS (which they don't do very well)
2. Speed -- before, the page needed to load + render before the backend was queried for club data. Now, the browser gets the HTML right away in the original request.

Relevant documentation for reading more: https://nextjs.org/docs#fetching-data-and-component-lifecycle