### PR TITLE
Strip Social Urls to Decrease Their Length

### DIFF
--- a/components/ClubPage/SocialIcons.js
+++ b/components/ClubPage/SocialIcons.js
@@ -47,10 +47,6 @@ const iconStyles = {
 
 const SocialIcons = ({ club }) =>
   socials
-    .map((data, idx) => {
-      data.index = idx
-      return data
-    })
     .filter(item => club[item.name])
     .map(item => (
       <div key={item.name}>

--- a/components/ClubPage/SocialLink.js
+++ b/components/ClubPage/SocialLink.js
@@ -1,5 +1,5 @@
 const stripUrl = url => {
-  return url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '')
+  return url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '').replace(/\/$/, '')
 }
 
 const SocialLink = ({ club, item, type }) => {

--- a/components/ClubPage/SocialLink.js
+++ b/components/ClubPage/SocialLink.js
@@ -1,6 +1,9 @@
+const stripUrl = url => {
+  return url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '')
+}
+
 const SocialLink = ({ club, item, type }) => {
-  let url
-  let text
+  let url, text
 
   if (type === 'email') {
     const email = club[item.name]
@@ -8,7 +11,7 @@ const SocialLink = ({ club, item, type }) => {
     text = email
   } else {
     url = club[item.name]
-    text = url
+    text = stripUrl(url)
   }
 
   return <a href={url}> {text}</a>


### PR DESCRIPTION
Uses a regex to strip "https" and "www" from social urls.

Maybe we could format social urls in specific ways (for example, displaying twitter page links as @twitterusername) instead?